### PR TITLE
Add missing account types

### DIFF
--- a/YNAB.Rest/AccountType.cs
+++ b/YNAB.Rest/AccountType.cs
@@ -12,6 +12,11 @@
         PayPal,
         MerchantAccount,
         InvestmentAccount,
-        Mortgage
+        Mortgage,
+        AutoLoan,
+        StudentLoan,
+        PersonalLoan,
+        MedicalDebt,
+        OtherDebt
     }
 }


### PR DESCRIPTION
Hello,

as seen in the API documentation YNAB now supports more Account Types than currently in the library: https://api.ynab.com/v1#/Accounts/getAccounts

![CleanShot 2024-02-10 at 21 47 58](https://github.com/jsmarble/YNAB.Rest/assets/15618191/abfaf781-a144-4309-9c11-55da002275e8)

So I've added all the missing Account Types. Let me know If I need to do anything else!