### PR TITLE
Resolved issue #21 of missing enum values for GoalTypes (used in Categories)

### DIFF
--- a/YNAB.Rest.Console/Program.cs
+++ b/YNAB.Rest.Console/Program.cs
@@ -120,6 +120,18 @@ namespace YNAB.RestConsole
                 Console.WriteLine();
 
                 payees.ToList().ForEach(p => Console.WriteLine($"{p.Id} | {p.Name}"));
+
+                Console.WriteLine($"Fetching Categories...");
+                var categoryResponse = await api.GetCategories(budget.Id);
+                var categoryGroups = categoryResponse.Data.CategoryGroups;
+                Console.WriteLine($"Found {categoryGroups.Count} category groups!");
+                Console.WriteLine();
+                categoryGroups.ToList().ForEach(p => Console.WriteLine($"{p.Id} | {p.Name}"));
+                var categories = categoryGroups.SelectMany(p => p.Categories).OrderBy(x => x.CategoryGroupId).ThenBy(x => x.Name).ToList();
+                Console.WriteLine($"Found {categories.Count} categories!");
+                Console.WriteLine();
+                categories.ToList().ForEach(p => Console.WriteLine($"{p.Id} | {p.Name}"));
+
             }
             catch (Exception ex)
             {

--- a/YNAB.Rest/Category.cs
+++ b/YNAB.Rest/Category.cs
@@ -7,7 +7,9 @@ namespace YNAB.Rest
     {
         TB,
         TBD,
-        MF
+        MF,
+        NEED,
+        DEBT
     }
 
     public class Category


### PR DESCRIPTION
Added two missing enum values, "NEED" and "DEBT" to GoalTypes enum, used by Category object.  Without thes values, fetches of Category data that contained these values would fail with a de-serialization error.

Also added demo code to program.cs for fetching categories.