### PR TITLE
Correctly deserialize subtransactions

### DIFF
--- a/YNAB.Rest/Transaction.cs
+++ b/YNAB.Rest/Transaction.cs
@@ -37,6 +37,7 @@ namespace YNAB.Rest
         public string AccountName { get; set; }
         public string PayeeName { get; set; }
         public string CategoryName { get; set; }
+        [JsonProperty(PropertyName = "subtransactions")]
         public IList<SubTransaction> SubTransactions { get; set; }
 
         /*


### PR DESCRIPTION
The YNAB API Transactions model does not snake subtransactions on transactions, but the code was written as if it does. To make this work without breaking existing code, I've added an attribute with the correct property name to get this working.

Validated this locally using a modified version of the console app in the solution.